### PR TITLE
Add response's headers validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ $app->add(new HKarlstrom\Middleware\OpenApiValidation('/path/to/openapi.json'),[
 | stripResponse         | bool      | false   | Strip additional parameters from response to prevent response validation error |
 | validateError         | bool      | false   | Should the error response be validated |
 | validateRequest       | bool      | true    | Should the request be validated |
-| validateResponse      | bool      | true    | Should the response be validated |
+| validateResponse      | bool      | true    | Should the response's body be validated |
+| validateResponseHeaders      | bool      | false    | Should the response's headers be validated |
 
 
 #### beforeHandler

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,7 @@
+# Roadmap
+This package is a fork of the [hkarlstrom/openapi-validation-middleware](https://github.com/hkarlstrom/openapi-validation-middleware).
+The goal of a fork is to extend its functionality.
+
+## New features:
+- validate `ServerRequestInterface`'s headers against the spec
+- validate `ResponseInterface`'s headers against the spec

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,0 @@
-# Roadmap
-This package is a fork of the [hkarlstrom/openapi-validation-middleware](https://github.com/hkarlstrom/openapi-validation-middleware).
-The goal of a fork is to extend its functionality.
-
-## New features:
-- validate `ServerRequestInterface`'s headers against the spec
-- validate `ResponseInterface`'s headers against the spec

--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -163,6 +163,18 @@ class OpenApiValidation implements MiddlewareInterface
                 ];
             }
         }
+        if($errors) {
+            return $errors;
+        }
+
+        // 3. Check header against schemas
+        foreach ($headersSpecifications as $headerName => $specification) {
+            $headerErrors = $this->validateObject($specification['schema'], $responseHeaders[$headerName]);
+            foreach ($headerErrors as &$error) {
+                $error['name'] = $headerName;
+            }
+            $errors = array_merge($errors, $headerErrors);
+        }
 
         return $errors;
     }

--- a/tests/ResponsesTest.php
+++ b/tests/ResponsesTest.php
@@ -82,4 +82,18 @@ class ResponsesTest extends BaseTest
         $this->assertSame('responseBody', $error['name']);
         $this->assertSame('error_required', $error['code']);
     }
+
+    public function testResponseMissedHeader()
+    {
+        $response = $this->response('get', '/missing/header', [
+            'options' => [
+                'validateResponseHeaders' => true,
+            ],
+        ]);
+        $this->assertSame(500, $response->getStatusCode());
+        $error = $this->json($response)['errors'][0];
+        $this->assertSame('responseHeader', $error['name']);
+        $this->assertSame('error_required', $error['code']);
+        $this->assertSame('X-Response-Id', $error['message']);
+    }
 }

--- a/tests/ResponsesTest.php
+++ b/tests/ResponsesTest.php
@@ -11,6 +11,8 @@
 
 namespace HKarlstrom\Middleware\OpenApiValidation;
 
+use Psr\Http\Message\ResponseInterface;
+
 class ResponsesTest extends BaseTest
 {
     public function testExampleResponse()
@@ -95,5 +97,23 @@ class ResponsesTest extends BaseTest
         $this->assertSame('responseHeader', $error['name']);
         $this->assertSame('error_required', $error['code']);
         $this->assertSame('X-Response-Id', $error['message']);
+    }
+
+    public function testResponseInvalidHeader()
+    {
+        $response = $this->response('get', '/missing/header', [
+            'options' => [
+                'validateResponseHeaders' => true,
+            ],
+            'customHandler' => function ($request, ResponseInterface $response) {
+                return $response
+                    ->withHeader('X-Response-Id', 1000)
+                    ->withJson(['ok' => true]);
+            }
+        ]);
+        $this->assertSame(500, $response->getStatusCode());
+        $error = $this->json($response)['errors'][0];
+        $this->assertSame('X-Response-Id', $error['name']);
+        $this->assertSame('error_type', $error['code']);
     }
 }

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -15,8 +15,7 @@
             "xResponseId": {
                 "required":true,
                 "schema": {
-                    "type": "string",
-                    "format": "uuid"
+                    "type": "string"
                 },
                 "description": "Unique response ID"
             }
@@ -24,11 +23,6 @@
         "responses": {
             "OkResponse":{
                 "description":"Ok",
-                "headers": {
-                    "X-Response-Id": {
-                        "$ref": "#/components/headers/xResponseId"
-                    }
-                },
                 "content":{
                     "application/json":{
                         "schema": {
@@ -44,11 +38,6 @@
             },
             "ErrorResponse":{
                 "description":"Error",
-                "headers": {
-                    "X-Response-Id": {
-                        "$ref": "#/components/headers/xResponseId"
-                    }
-                },
                 "content":{
                     "application/json":{
                         "schema": {
@@ -286,6 +275,32 @@
                     },
                     "400": {
                         "$ref":"#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/missing/header": {
+            "get": {
+                "operationId":"testMissingHeader",
+                "responses": {
+                    "200": {
+                        "headers": {
+                            "X-Response-Id": {
+                                "$ref": "#/components/headers/xResponseId"
+                            }
+                        },
+                        "content":{
+                            "application/json":{
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -11,9 +11,24 @@
         }
     ],
     "components":{
+        "headers": {
+            "xResponseId": {
+                "required":true,
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "description": "Unique response ID"
+            }
+        },
         "responses": {
             "OkResponse":{
                 "description":"Ok",
+                "headers": {
+                    "X-Response-Id": {
+                        "$ref": "#/components/headers/xResponseId"
+                    }
+                },
                 "content":{
                     "application/json":{
                         "schema": {
@@ -29,6 +44,11 @@
             },
             "ErrorResponse":{
                 "description":"Error",
+                "headers": {
+                    "X-Response-Id": {
+                        "$ref": "#/components/headers/xResponseId"
+                    }
+                },
                 "content":{
                     "application/json":{
                         "schema": {


### PR DESCRIPTION
This PR works only with this PR: https://github.com/hkarlstrom/openapi-reader/pull/1

This PR:
- adds new option `validateResponseHeaders`
- returns 500 if required headers are not presented in the response
- returns 500 if a header doesn't match the schema
