### PR TITLE
Upgraded openapi-reader to support YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 .DS_Store
 /vendor/
+.idea/
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PSR-7 and PSR-15 OpenAPI Validation Middleware
 
-The middleware parses an OpenAPI definition document (openapi.json) and validates:
+The middleware parses an OpenAPI definition document (openapi.json or openapi.yaml) and validates:
 * Request parameters (path, query)
 * Request body
 * Response body
@@ -19,7 +19,7 @@ It's recommended that you use [Composer](https://getcomposer.org/download) to in
 composer require hkarlstrom/openapi-validation-middleware
 ```
 
-Use [Swagger/OpenAPI CLI](https://www.npmjs.com/package/swagger-cli) to validate openapi.json file, as the middleware assumes it to be valid.
+Use [Swagger/OpenAPI CLI](https://www.npmjs.com/package/swagger-cli) to validate openapi.json/openapi.yaml file, as the middleware assumes it to be valid.
 
 
 ## Usage
@@ -52,9 +52,9 @@ $app->add(new HKarlstrom\Middleware\OpenApiValidation('/path/to/openapi.json'),[
 | additionalParameters    | bool      | false   | Allow additional parameters in query |
 | beforeHandler           | callable  | null    | Instructions [below](README.md#beforehandler) |
 | errorHandler            | callable  | null    | Instructions [below](README.md#errorhandler) |
-| exampleResponse         | bool      | false   | Return example response from openapi.json if route implementation is empty |
+| exampleResponse         | bool      | false   | Return example response from openapi.json/openapi.yaml if route implementation is empty |
 | missingFormatException  | bool      | true    | Throw an exception if a format validator is missing |
-| pathNotFoundException   | bool      | true    | Throw an exception if the path is not found in openapi.json |
+| pathNotFoundException   | bool      | true    | Throw an exception if the path is not found in openapi.json/openapi.yaml |
 | setDefaultParameters    | bool      | false   | Set the default parameter values for missing parameters and alter the request object |
 | stripResponse           | bool      | false   | Strip additional attributes from response to prevent response validation error |
 | stripResponseHeaders    | bool      | false   | Strip additional headers from response to prevent response validation error |
@@ -108,7 +108,7 @@ $app->add($mw);
 
 #### Respect Validation
 
-You can use [all the validators](http://respect.github.io/Validation/docs/validators.html) just by setting the `format` property in your openapi.json file.
+You can use [all the validators](http://respect.github.io/Validation/docs/validators.html) just by setting the `format` property in your openapi.json/openapi.yaml file.
 ```json
 "schema":{
     "type" : "string",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.1",
         "ext-json": "*",
         "ckr/arraymerger": "^2.0",
-        "hkarlstrom/openapi-reader": "~0.2",
+        "hkarlstrom/openapi-reader": "^0.3",
         "opis/json-schema": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
     ],
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
         "ckr/arraymerger": "^2.0",
-        "hkarlstrom/openapi-reader": "^0.2.1",
+        "hkarlstrom/openapi-reader": "~0.2",
         "opis/json-schema": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76f404d9f22d6b91782dbee80ff2eeb7",
+    "content-hash": "acb415ffc62507497c5ec2a975c4a1e7",
     "packages": [
         {
             "name": "ckr/arraymerger",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b80205984821fc4ee9dc7eef64d0b39",
+    "content-hash": "76f404d9f22d6b91782dbee80ff2eeb7",
     "packages": [
         {
             "name": "ckr/arraymerger",
@@ -47,20 +47,24 @@
         },
         {
             "name": "hkarlstrom/openapi-reader",
-            "version": "0.2.2",
+            "version": "0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hkarlstrom/openapi-reader.git",
-                "reference": "396b4d3dd971e119875fc9530b2594838bbbe648"
+                "reference": "4db8911aec93c69fa75993f8c8adb58d47f4728d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hkarlstrom/openapi-reader/zipball/396b4d3dd971e119875fc9530b2594838bbbe648",
-                "reference": "396b4d3dd971e119875fc9530b2594838bbbe648",
+                "url": "https://api.github.com/repos/hkarlstrom/openapi-reader/zipball/4db8911aec93c69fa75993f8c8adb58d47f4728d",
+                "reference": "4db8911aec93c69fa75993f8c8adb58d47f4728d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1",
+                "rize/uri-template": "^0.3.2",
+                "symfony/yaml": "^4.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.3.5"
@@ -68,7 +72,8 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "HKarlstrom\\OpenApiReader\\": "src"
+                    "HKarlstrom\\OpenApiReader\\": "src",
+                    "HKarlstrom\\OpenApiReader\\Tests\\": "tests"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -81,8 +86,8 @@
                     "email": "henrik.karlstrom@gmail.com"
                 }
             ],
-            "description": "Library for parsing OpenAPI json documentation files.",
-            "time": "2019-01-16T18:01:54+00:00"
+            "description": "Library for parsing OpenAPI JSON/YAML documentation files.",
+            "time": "2019-01-23T08:29:53+00:00"
         },
         {
             "name": "opis/json-schema",
@@ -418,6 +423,108 @@
             "time": "2018-11-04T21:58:45+00:00"
         },
         {
+            "name": "rize/uri-template",
+            "version": "0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rize/UriTemplate.git",
+                "reference": "9e5fdd5c47147aa5adf7f760002ee591ed37b9ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/9e5fdd5c47147aa5adf7f760002ee591ed37b9ca",
+                "reference": "9e5fdd5c47147aa5adf7f760002ee591ed37b9ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Rize\\UriTemplate": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marut K",
+                    "homepage": "http://twitter.com/rezigned"
+                }
+            ],
+            "description": "PHP URI Template (RFC 6570) supports both expansion & extraction",
+            "keywords": [
+                "RFC 6570",
+                "template",
+                "uri"
+            ],
+            "time": "2017-06-14T03:57:53+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.10.0",
             "source": {
@@ -475,6 +582,65 @@
                 "shim"
             ],
             "time": "2018-09-21T13:07:52+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d0aa6c0ea484087927b49fd513383a7d36190ca6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d0aa6c0ea484087927b49fd513383a7d36190ca6",
+                "reference": "d0aa6c0ea484087927b49fd513383a7d36190ca6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "tuupola/callable-handler",
@@ -2148,64 +2314,6 @@
             "time": "2019-01-15T13:21:25+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2018-08-06T14:22:27+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -2303,7 +2411,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-json": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Hi, man.
I've upgraded openapi-reader constraint, in order to add support for OpenAPI schema in YAML format.
I haven't added any further tests, since I think they would only test the project dependency: am I wrong?
Thanks in advance.