### PR TITLE
Add a failing test for nullable values

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -91,16 +91,16 @@
         },
         {
             "name": "opis/json-schema",
-            "version": "1.0.14",
+            "version": "1.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/json-schema.git",
-                "reference": "d79f9f4ab1dbbb88799b49cb4194d4229c4f6ef6"
+                "reference": "ff5c65a03373bf5fbf6bf14a83d282e093091c8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/json-schema/zipball/d79f9f4ab1dbbb88799b49cb4194d4229c4f6ef6",
-                "reference": "d79f9f4ab1dbbb88799b49cb4194d4229c4f6ef6",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/ff5c65a03373bf5fbf6bf14a83d282e093091c8d",
+                "reference": "ff5c65a03373bf5fbf6bf14a83d282e093091c8d",
                 "shasum": ""
             },
             "require": {
@@ -149,7 +149,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-01-16T15:54:41+00:00"
+            "time": "2019-01-18T14:11:57+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1846,16 +1846,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f"
+                "reference": "4a43e9af57b4afa663077b9bc85255dbc6e8a2bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/febd209a219cea7b56ad799b30ebbea34b71eb8f",
-                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4a43e9af57b4afa663077b9bc85255dbc6e8a2bd",
+                "reference": "4a43e9af57b4afa663077b9bc85255dbc6e8a2bd",
                 "shasum": ""
             },
             "require": {
@@ -1892,7 +1892,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2018-11-25T09:31:21+00:00"
+            "time": "2019-01-28T15:26:03+00:00"
         },
         {
             "name": "sebastian/exporter",

--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -260,14 +260,7 @@ class OpenApiValidation implements MiddlewareInterface
                 switch ($mediaType) {
                     case 'application/json':
                         if (!empty($requestBodyData)) {
-                            $objectErrors = $this->validateObject($requestMediaType->schema, $requestBodyData);
-                            foreach ($objectErrors as $error) {
-                                if (!('error_type' == $error['code']
-                                    && 'null' == $error['used']
-                                    && SchemaHelper::isNullable($requestMediaType->schema, explode('.', $error['name'])))) {
-                                    $errors[] = $error;
-                                }
-                            }
+                            $errors = $this->validateObject($requestMediaType->schema, $requestBodyData);
                         }
                         break;
                     case 'multipart/form-data':
@@ -364,7 +357,7 @@ class OpenApiValidation implements MiddlewareInterface
         }
         $validator = new Validator();
         $validator->setFormats($this->formatContainer);
-        $schema = SchemaHelper::mergeAllOf($schema);
+        $schema = SchemaHelper::openApiToJsonSchema($schema);
         try {
             $value  = json_decode(json_encode($value));
             $schema = json_decode(json_encode($schema));

--- a/src/OpenApiValidation/Helpers/Schema.php
+++ b/src/OpenApiValidation/Helpers/Schema.php
@@ -13,20 +13,7 @@ namespace HKarlstrom\Middleware\OpenApiValidation\Helpers;
 
 class Schema
 {
-    public static function addRecursive(array $schema, string $attribute, $value) : array
-    {
-        if (($schema['type'] ?? null) === 'object') {
-            $schema[$attribute] = $value;
-        }
-        foreach ($schema as $attr => $val) {
-            if (is_array($val)) {
-                $schema[$attr] = self::addRecursive($schema[$attr], $attribute, $value);
-            }
-        }
-        return $schema;
-    }
-
-    public static function mergeAllOf(array $schema) : array
+    public static function openApiToJsonSchema(array $schema) : array
     {
         if (isset($schema['allOf']) && is_array($schema['allOf'])) {
             $allOf = $schema['allOf'];
@@ -38,9 +25,13 @@ class Schema
             }
             $schema = \Ckr\Util\ArrayMerger::doMerge($schema, $merged);
         }
+        if ($schema['nullable'] ?? false) {
+            unset($schema['nullable']);
+            $schema['type'] = [$schema['type'], 'null'];
+        }
         foreach ($schema as $attr => $val) {
             if (is_array($val)) {
-                $schema[$attr] = self::mergeAllOf($val);
+                $schema[$attr] = self::openApiToJsonSchema($val);
             }
         }
         return $schema;
@@ -93,10 +84,5 @@ class Schema
         };
         $callback($schema, $formats);
         return $formats;
-    }
-
-    public static function isNullable(array $schema, array $path) : bool
-    {
-        return true;
     }
 }

--- a/tests/ResponsesTest.php
+++ b/tests/ResponsesTest.php
@@ -116,4 +116,15 @@ class ResponsesTest extends BaseTest
         $this->assertSame('string', $error['used']);
         $this->assertSame('header', $error['in']);
     }
+
+    public function testResponseWithNullableBodyAttributes() {
+        $response = $this->response('get', '/response/nullable', [
+            'customHandler' => function ($request, ResponseInterface $response) {
+                return $response->withJson(['ok' => null]);
+            },
+        ]);
+        $json = $this->json($response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(null, $json['ok']);
+    }
 }

--- a/tests/ResponsesTest.php
+++ b/tests/ResponsesTest.php
@@ -117,7 +117,8 @@ class ResponsesTest extends BaseTest
         $this->assertSame('header', $error['in']);
     }
 
-    public function testResponseWithNullableBodyAttributes() {
+    public function testResponseWithNullableBodyAttributes()
+    {
         $response = $this->response('get', '/response/nullable', [
             'customHandler' => function ($request, ResponseInterface $response) {
                 return $response->withJson(['ok' => null]);

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -657,6 +657,28 @@
                     }
                 }
             }
+        },
+        "/response/nullable": {
+            "get": {
+                "operationId": "getNullableResponse",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean",
+                                            "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
[OpenAPI schema](https://swagger.io/docs/specification/data-models/data-types/) supports nullable attributes like this:
```json
"schema": {
                                    "type": "object",
                                    "properties": {
                                        "ok": {
                                            "type": "boolean",
                                            "nullable": true
                                        }
                                    }
                                }
```

Added a test which confirms this behaviour.