### PR TITLE
Added JSON_PRESERVE_ZERO_FRACTION

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -210,7 +210,7 @@ class OpenApiValidation implements MiddlewareInterface
                 }
             }
             $errors   = $notAdditionalOrNullErrors;
-            $response = $response->withBody((new StreamFactory())->createStream(json_encode($responseBodyData)));
+            $response = $response->withBody((new StreamFactory())->createStream(json_encode($responseBodyData, JSON_PRESERVE_ZERO_FRACTION)));
         }
         return $errors;
     }
@@ -359,8 +359,8 @@ class OpenApiValidation implements MiddlewareInterface
         $validator->setFormats($this->formatContainer);
         $schema = SchemaHelper::openApiToJsonSchema($schema);
         try {
-            $value  = json_decode(json_encode($value));
-            $schema = json_decode(json_encode($schema));
+            $value  = json_decode(json_encode($value, JSON_PRESERVE_ZERO_FRACTION));
+            $schema = json_decode(json_encode($schema, JSON_PRESERVE_ZERO_FRACTION));
             $result = $validator->dataValidation($value, $schema, 99);
         } catch (Exception $e) {
             return [[
@@ -460,7 +460,7 @@ class OpenApiValidation implements MiddlewareInterface
                 $exampleResponseBodyData = array_merge($exampleResponseBodyData, $requestBodyData);
             }
             $response = $response
-                ->withBody((new StreamFactory())->createStream(json_encode($exampleResponseBodyData)))
+                ->withBody((new StreamFactory())->createStream(json_encode($exampleResponseBodyData, JSON_PRESERVE_ZERO_FRACTION)))
                 ->withHeader('Content-Type', $mediaType.';charset=utf-8');
             if (is_numeric($responseObject->statusCode)) {
                 $response = $response->withStatus($responseObject->statusCode);
@@ -483,7 +483,7 @@ class OpenApiValidation implements MiddlewareInterface
             $json['errors'] = $errors;
         }
         $response = $response->withHeader('Content-Type', 'application/json;charset=utf-8');
-        return $response->withBody((new StreamFactory())->createStream(json_encode($json)));
+        return $response->withBody((new StreamFactory())->createStream(json_encode($json, JSON_PRESERVE_ZERO_FRACTION)));
     }
 
     private function parseErrors(ValidationError $error, $name = null, $in = null) : array

--- a/src/OpenApiValidation/Property.php
+++ b/src/OpenApiValidation/Property.php
@@ -27,7 +27,7 @@ class Property
         $this->name     = $name;
         $this->in       = $in;
         $this->required = $required;
-        $this->schema   = json_decode(json_encode($schema));
+        $this->schema   = json_decode(json_encode($schema, JSON_PRESERVE_ZERO_FRACTION));
         $this->value    = $value ?? null;
         if (null == $this->value) {
             return;


### PR DESCRIPTION
Hi, man.

I've added **JSON_PRESERVE_ZERO_FRACTION** flag to all json_encode() occurrences of your code, because defaul json_encode() behaviour would remove zero fraction.

The purpose is: in case you want to validate a float number against pattern **\d+\.\d+**, currently numbers with **\d+\.[0]+** (only zeroes as decimal part) are converted to **\d+**, making validation fail.

I'm aware that **1.0** and **1** are perfectly the same thing and that OpenAPI's **number** type matches both. Anyway specific cases where you want to enforce a non-empty decimal part currently cannot validate properly.

Let me know if it sounds as a reasonable thought or if you need an example.

Thanks in advance, as usual!