### PR TITLE
Enable formatted JSON requests to be validated

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -243,13 +243,10 @@ class OpenApiValidation implements MiddlewareInterface
         if ($requestBody && $requestMediaType = $requestBody->getContent($mediaType)) {
             if (empty($requestBodyData) && $requestBody->required) {
                 $errors[] = ['name' => 'requestBody', 'code' => 'error_required'];
-             } else {
-                if ($requestBodyData && $this->isJsonMediaType($mediaType)) {
-                    $errors = array_merge($errors, $this->validateObject($requestMediaType->schema, $requestBodyData));
-                }
-                if ($mediaType === 'multipart/form-data') {
-                    $errors = array_merge($errors, $this->validateFormData($requestMediaType->schema, $requestMediaType->encoding, $request));
-                }
+            } elseif ($requestBodyData && $this->isJsonMediaType($mediaType)) {
+                $errors = array_merge($errors, $this->validateObject($requestMediaType->schema, $requestBodyData));
+            } elseif ('multipart/form-data' === $mediaType) {
+                $errors = array_merge($errors, $this->validateFormData($requestMediaType->schema, $requestMediaType->encoding, $request));
             }
         }
         return $errors;
@@ -520,9 +517,9 @@ class OpenApiValidation implements MiddlewareInterface
         return mb_strtolower($contentTypeParts[0]);
     }
 
-    private function isJsonMediaType(string $type): bool
+    private function isJsonMediaType(string $type) : bool
     {
         // Allow JSON and JSON-formatted (eg: JSON-API) requests to be validated.
-        return $type === 'application/json' || strpos($type, '+json') !== false;
+        return 'application/json' === $type || false !== mb_strpos($type, '+json');
     }
 }

--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -243,16 +243,12 @@ class OpenApiValidation implements MiddlewareInterface
         if ($requestBody && $requestMediaType = $requestBody->getContent($mediaType)) {
             if (empty($requestBodyData) && $requestBody->required) {
                 $errors[] = ['name' => 'requestBody', 'code' => 'error_required'];
-            } else {
-                switch ($mediaType) {
-                    case 'application/json':
-                        if (!empty($requestBodyData)) {
-                            $errors = array_merge($errors, $this->validateObject($requestMediaType->schema, $requestBodyData));
-                        }
-                        break;
-                    case 'multipart/form-data':
-                        $errors = array_merge($errors, $this->validateFormData($requestMediaType->schema, $requestMediaType->encoding, $request));
-                        break;
+             } else {
+                if ($requestBodyData && $this->isJsonMediaType($mediaType)) {
+                    $errors = array_merge($errors, $this->validateObject($requestMediaType->schema, $requestBodyData));
+                }
+                if ($mediaType === 'multipart/form-data') {
+                    $errors = array_merge($errors, $this->validateFormData($requestMediaType->schema, $requestMediaType->encoding, $request));
                 }
             }
         }
@@ -522,5 +518,11 @@ class OpenApiValidation implements MiddlewareInterface
         }
         $contentTypeParts = preg_split('/\s*[;,]\s*/', $header[0]);
         return mb_strtolower($contentTypeParts[0]);
+    }
+
+    private function isJsonMediaType(string $type): bool
+    {
+        // Allow JSON and JSON-formatted (eg: JSON-API) requests to be validated.
+        return $type === 'application/json' || strpos($type, '+json') !== false;
     }
 }


### PR DESCRIPTION
Allows for formats like JSON-API (`application/vnd.api+json`) to be used.