### PR TITLE
Prevent attempts to style array query params

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -279,11 +279,13 @@ class OpenApiValidation implements MiddlewareInterface
                     if (!isset($queryParams[$name])) {
                         continue;
                     }
-                    $queryParams[$name] = $this->styleValue(
-                        $parameter->in,
-                        $parameter->style,
-                        $parameter->explode,
-                        $queryParams[$name]);
+                    if (is_string($queryParams[$name])) {
+                        $queryParams[$name] = $this->styleValue(
+                            $parameter->in,
+                            $parameter->style,
+                            $parameter->explode,
+                            $queryParams[$name]);
+                    }
                     $request = $request->withQueryParams($queryParams);
                     break;
             }

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -163,4 +163,12 @@ class ParametersTest extends BaseTest
         $json     = $this->json($response);
         $this->assertTrue($json['ok']);
     }
+
+    public function testStyleDeepObject(): void
+    {
+        $response = $this->response('get', '/parameters', ['query' => ['foo' => 'aaa', 'filter' => ['ids' => '1,2,3']]]);
+        $json     = $this->json($response);
+
+        $this->assertTrue($json['ok']);
+    }
 }

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -324,6 +324,15 @@
                             }
                         },
                         "style": "pipeDelimited"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filter",
+                        "style": "deepObject",
+                        "explode": true,
+                        "schema": {
+                            "type": "object"
+                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Query parameters with `style: deepObject, explode: true` would attempt to be styled and fail type check.