### PR TITLE
FIX "continue" targeting switch is equivalent to "break". Did you mea…

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -277,7 +277,7 @@ class OpenApiValidation implements MiddlewareInterface
                 case 'query':
                     $queryParams = $request->getQueryParams();
                     if (!isset($queryParams[$name])) {
-                        continue;
+                        break;
                     }
                     if (is_string($queryParams[$name])) {
                         $queryParams[$name] = $this->styleValue(

--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -273,21 +273,16 @@ class OpenApiValidation implements MiddlewareInterface
                 continue;
             }
             $name = $parameter->name;
-            switch ($parameter->in) {
-                case 'query':
-                    $queryParams = $request->getQueryParams();
-                    if (!isset($queryParams[$name])) {
-                        break;
-                    }
-                    if (is_string($queryParams[$name])) {
-                        $queryParams[$name] = $this->styleValue(
-                            $parameter->in,
-                            $parameter->style,
-                            $parameter->explode,
-                            $queryParams[$name]);
-                    }
+            if ('query' === $parameter->in) {
+                $queryParams = $request->getQueryParams();
+                if (is_string($queryParams[$name] ?? null)) {
+                    $queryParams[$name] = $this->styleValue(
+                        $parameter->in,
+                        $parameter->style,
+                        $parameter->explode,
+                        $queryParams[$name]);
                     $request = $request->withQueryParams($queryParams);
-                    break;
+                }
             }
         }
         return $request;
@@ -344,7 +339,7 @@ class OpenApiValidation implements MiddlewareInterface
                         if ('error_type' === $parsedError['code']
                             && 'integer' === $parsedError['expected']
                             && 'string' === $parsedError['used']
-                            && preg_match("/^[0-9]$/", $parsedError['value'])) {
+                            && preg_match('/^[0-9]$/', $parsedError['value'])) {
                             $discard = true;
                         }
                         if (!$discard) {


### PR DESCRIPTION
…n to use "continue 2"? WARNING

From PHP 7.3 the usage of `continue` in a switch statement produces a WARNING, under certain configurations it can produce an error exception