### PR TITLE
response header validation: as in response body validation, disabled …

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -140,6 +140,9 @@ class OpenApiValidation implements MiddlewareInterface
     {
         $code                  = $response->getStatusCode();
         $responseObject        = $this->openapi->getOperationResponse($path, $method, $code);
+        if (null === $responseObject) { // Not in file
+            return [];
+        }
         $headersSpecifications = $responseObject->getHeaders();
         $responseHeaders       = $response->getHeaders();
 


### PR DESCRIPTION
…validation in case of path not described by OpenAPI schema