### PR TITLE
Prevent undefined index notice

### DIFF
--- a/src/OpenApiValidation/Helpers/Schema.php
+++ b/src/OpenApiValidation/Helpers/Schema.php
@@ -27,7 +27,9 @@ class Schema
         }
         if ($schema['nullable'] ?? false) {
             unset($schema['nullable']);
-            $schema['type'] = [$schema['type'], 'null'];
+            if (isset($schema['type'])) {
+                $schema['type'] = [$schema['type'], 'null'];
+            }
         }
         foreach ($schema as $attr => $val) {
             if (is_array($val)) {

--- a/tests/ResponsesTest.php
+++ b/tests/ResponsesTest.php
@@ -128,4 +128,16 @@ class ResponsesTest extends BaseTest
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(null, $json['ok']);
     }
+
+    public function testResponsesWithAnyOfBodyAttribute()
+    {
+        $response = $this->response('get', '/response/any-of', [
+            'customHandler' => function ($request, ResponseInterface $response) {
+                return $response->withJson(['value' => 15]);
+            },
+        ]);
+        $json = $this->json($response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(15, $json['value']);
+    }
 }

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -716,6 +716,7 @@
                 "operationId": "getNullableResponse",
                 "responses": {
                     "200": {
+                        "description": "Test for nullable type",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -825,6 +826,31 @@
                     },
                     "400": {
                         "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/response/any-of": {
+            "get": {
+                "operationId": "getAnyOf",
+                "responses": {
+                    "200": {
+                        "description": "Test for nullable type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "anyOf": [
+                                                {"type": "string"},
+                                                {"type":  "integer"}
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Prevents an "undefined index" warning when `type` is not defined, such as with `anyOf` schemas.

Refs #12