### PR TITLE
application/x-www-form-urlencoded request body validation

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -276,7 +276,8 @@ class OpenApiValidation implements MiddlewareInterface
                     $requestBodyData = json_encode($requestBodyData, JSON_PRESERVE_ZERO_FRACTION);
                 }
                 $errors = array_merge($errors, $this->validateObject($requestMediaType->schema, $requestBodyData));
-            } elseif ('multipart/form-data' === $mediaType) {
+            } elseif ('multipart/form-data' === $mediaType
+                || 'application/x-www-form-urlencoded' === $mediaType) {
                 $errors = array_merge($errors, $this->validateFormData($requestMediaType->schema, $requestMediaType->encoding, $request));
             }
         }

--- a/tests/BaseFormTest.php
+++ b/tests/BaseFormTest.php
@@ -23,7 +23,7 @@ class BaseFormTest extends TestCase
 
     public function testFormData()
     {
-        $response = $this->response('post', '/upload', [
+        $response = $this->response('post', '/form-data', [
             'formData' => [
                 'id' => 100,
                 'text' => 'somestring',
@@ -43,7 +43,7 @@ class BaseFormTest extends TestCase
 
     public function testFormDataErrors()
     {
-        $response = $this->response('post', '/upload', [
+        $response = $this->response('post', '/form-data', [
             'formData' => [
                 'id' => 'invalid-type',
                 'text' => 'somestring',
@@ -62,9 +62,9 @@ class BaseFormTest extends TestCase
         // array: not matching minItems validation
 
         $json = $this->json($response);
-        $this->assertSame('error_content_type', $json['errors'][0]['code']);
-        $this->assertSame('image/png', $json['errors'][0]['used']);
-        $this->assertSame(['text/plain', 'image/jpeg'], $json['errors'][0]['expected']);
+
+        // TODO: Detailed response validation
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     protected function json(ResponseInterface $response) : array

--- a/tests/BaseFormTest.php
+++ b/tests/BaseFormTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * OpenAPI Validation Middleware.
+ *
+ * @see       https://github.com/hkarlstrom/openapi-validation-middleware
+ *
+ * @copyright Copyright (c) 2018 Henrik Karlström
+ * @license   MIT
+ */
+
+namespace HKarlstrom\Middleware\OpenApiValidation;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Slim\App;
+use Slim\Http\Environment;
+use Slim\Http\Request;
+
+class BaseFormTest extends TestCase
+{
+    protected $openapiFile = __DIR__.'/testapi.json';
+
+    public function testFormData()
+    {
+        $response = $this->response('post', '/upload', [
+            'formData' => [
+                'id' => 100,
+                'text' => 'somestring',
+                'array' => [
+                    ['name' => 'test', 'value' => 'test2'],
+                    ['name' => 'test', 'value' => 'test2'],
+                ],
+                'object' => [
+                    'name' => 'test',
+                    'value' => 'test2',
+                ]
+            ],
+        ]);
+        $json = $this->json($response);
+        $this->assertTrue($json['ok']);
+    }
+
+    public function testFormDataErrors()
+    {
+        $response = $this->response('post', '/upload', [
+            'formData' => [
+                'id' => 'invalid-type',
+                'text' => 'somestring',
+                'arr' => [
+                    ['name' => 'test', 'value' => 'test2'],
+                ],
+                'object' => [
+                    'name' => 'test',
+                    'value' => 'test2',
+                ]
+            ],
+        ]);
+        // id: invalid type (expected: integer)
+        // text: missing
+        // object: missing value property
+        // array: not matching minItems validation
+
+        $json = $this->json($response);
+        $this->assertSame('error_content_type', $json['errors'][0]['code']);
+        $this->assertSame('image/png', $json['errors'][0]['used']);
+        $this->assertSame(['text/plain', 'image/jpeg'], $json['errors'][0]['expected']);
+    }
+
+    protected function json(ResponseInterface $response) : array
+    {
+        $response->getBody()->rewind();
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    protected function response($method, $path, array $args = []) : ResponseInterface
+    {
+        $uri = $path;
+        foreach ($args['path'] ?? [] as $var => $val) {
+            $uri = str_replace('{'.$var.'}', $val, $uri);
+        }
+        $env = Environment::mock([
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI'    => $uri,
+            'QUERY_STRING'   => http_build_query($args['query'] ?? []),
+            'SERVER_NAME'    => 'test.com',
+            'CONTENT_TYPE'   => 'application/json;charset=utf8',
+        ]);
+        $request = Request::createFromEnvironment($env);
+        if (isset($args['formData'])) {
+            $request->getBody()->write(http_build_query($args['formData'] ?? []));
+            $request->getBody()->rewind();
+            $request = $request->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+        }
+        $app = new App(['request' => $request]);
+
+        $callback = function ($req, $res) {
+            return $res->withJson(['ok' => true]);
+        };
+
+        $app->map([$method], $path, $callback);
+
+        $app->map([$method], '[/{params:.*}]', $callback);
+        $mw = new \HKarlstrom\Middleware\OpenApiValidation($this->openapiFile, $args['options'] ?? []);
+        $app->add($mw);
+
+        return $app->run(true);
+    }
+}

--- a/tests/BaseFormTest.php
+++ b/tests/BaseFormTest.php
@@ -41,30 +41,130 @@ class BaseFormTest extends TestCase
         $this->assertTrue($json['ok']);
     }
 
-    public function testFormDataErrors()
+    public function providerFormDataErrors()
+    {
+        return [
+            // id: invalid type (expected: integer)
+            'invalid_type' => [
+                [
+                    'id' => 'invalid-type',
+                    'text' => 'somestring',
+                    'array' => [
+                        ['name' => 'test', 'value' => 'test2'],
+                        ['name' => 'test', 'value' => 'test2'],
+                    ],
+                    'object' => [
+                        'name' => 'test',
+                        'value' => 'test2',
+                    ]
+                ],
+                [
+                    'message' => 'Request validation failed',
+                    'errors' => [
+                        [
+                            'name' => 'id',
+                            'code' => 'error_type',
+                            'value' => 'invalid-type',
+                            'in' => 'form-data',
+                            'expected' => 'integer',
+                            'used' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            // text: missing
+            'text_missing' => [
+                [
+                    'id' => 100,
+                    'array' => [
+                        ['name' => 'test', 'value' => 'test2'],
+                        ['name' => 'test', 'value' => 'test2'],
+                    ],
+                    'object' => [
+                        'name' => 'test',
+                        'value' => 'test2',
+                    ]
+                ],
+                [
+                    'message' => 'Request validation failed',
+                    'errors' => [
+                        [
+                            'name' => 'text',
+                            'code' => 'error_required',
+                            'in' => 'form-data',
+                        ],
+                    ],
+                ],
+            ],
+            // object: missing value property
+            'object_no_property' => [
+                [
+                    'id' => 100,
+                    'text' => 'somestring',
+                    'array' => [
+                        ['name' => 'test', 'value' => 'test2'],
+                        ['name' => 'test', 'value' => 'test2'],
+                    ],
+                    'object' => [
+                        'name' => 'test',
+                    ]
+                ],
+                [
+                    'message' => 'Request validation failed',
+                    'errors' => [
+                        [
+                            'name' => 'object.value',
+                            'code' => 'error_required',
+                            'in' => 'form-data',
+                        ],
+                    ],
+                ],
+            ],
+            // array: not matching minItems validation
+            'array_to_few_items' => [
+                [
+                    'id' => 100,
+                    'text' => 'somestring',
+                    'array' => [
+                        ['name' => 'test', 'value' => 'test2'],
+                    ],
+                    'object' => [
+                        'name' => 'test',
+                        'value' => 'test2',
+                    ]
+                ],
+                [
+                    'message' => 'Request validation failed',
+                    'errors' => [
+                        [
+                            'name' => 'array',
+                            'code' => 'error_minItems',
+                            'value' => [
+                                ['name' => 'test', 'value' => 'test2'],
+                            ],
+                            'in' => 'form-data',
+                            'min' => 2,
+                            'count' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFormDataErrors
+     */
+    public function testFormDataErrors(array $formData, array $expectedResponse)
     {
         $response = $this->response('post', '/form-data', [
-            'formData' => [
-                'id' => 'invalid-type',
-                'text' => 'somestring',
-                'arr' => [
-                    ['name' => 'test', 'value' => 'test2'],
-                ],
-                'object' => [
-                    'name' => 'test',
-                    'value' => 'test2',
-                ]
-            ],
+            'formData' => $formData,
         ]);
-        // id: invalid type (expected: integer)
-        // text: missing
-        // object: missing value property
-        // array: not matching minItems validation
 
         $json = $this->json($response);
 
-        // TODO: Detailed response validation
         $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame($expectedResponse, $json);
     }
 
     protected function json(ResponseInterface $response) : array

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -764,6 +764,7 @@
                         "application/x-www-form-urlencoded": {
                             "schema": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "id": {
                                         "type": "integer"
@@ -801,7 +802,8 @@
                                         },
                                         "required": ["name", "value"]
                                     }
-                                }
+                                },
+                                "required": ["id", "text", "array", "object"]
                             }
                         }
                     }

--- a/tests/testapi.json
+++ b/tests/testapi.json
@@ -756,6 +756,66 @@
                 }
             }
         },
+        "/form-data": {
+            "post": {
+                "operationId": "testBaseForm",
+                "requestBody": {
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "array": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["name", "value"]
+                                        },
+                                        "minItems": 2
+                                    },
+                                    "object": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["name", "value"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/OkResponse"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
         "/path/{foo}/path/{bar}": {
             "get": {
                 "operationId": "pathParamTest",


### PR DESCRIPTION
Hello! I appreciate work you have done implementing this library, it's really great for base validation for API methods requests and responses. :)

I've found that library does not support `application/x-www-form-urlencoded` content type in request body. Code needs only small tweak to make it support this encoding type used by all HTML forms and as standard encoding in most HTTP clients.

According to `ServerRequestInterface` behavior for `getParsedBody` must be the same for both `multipart/form-data` and `application/x-www-form-urlencoded` so I'm sure that your implementation will source data properly:

```
/**
 * Retrieve any parameters provided in the request body.
 *
 * If the request Content-Type is either application/x-www-form-urlencoded
 * or multipart/form-data, and the request method is POST, this method MUST
 * return the contents of $_POST.
 *
 * Otherwise, this method may return any results of deserializing
 * the request body content; as parsing returns structured content, the
 * potential types MUST be arrays or objects only. A null value indicates
 * the absence of body content.
 *
 * @return null|array|object The deserialized body parameters, if any.
 *     These will typically be an array or object.
 */
public function getParsedBody();
```

Feel free to contact me if you need some corrections in my changes. 