### PR TITLE
Return [] if not defined as a json response

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -204,6 +204,9 @@ class OpenApiValidation implements MiddlewareInterface
             $mediaType      = $responseObject->getDefaultMediaType();
             $responseSchema = $responseObject->getContent($mediaType)->schema;
         }
+        if ($mediaType !== 'application/json') { // not supposed to be a json response. can't validate reliably.
+            return [];
+        }
         if (null === $responseBodyData && $responseSchema) {
             return [['name' => 'responseBody', 'code' => 'error_required']];
         }


### PR DESCRIPTION
If I'm using response type text/html, then it can't very well determine if the response is valid using json_decode.
Fixes #27