### PR TITLE
Get first element of array of types if needed

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -344,7 +344,9 @@ class OpenApiValidation implements MiddlewareInterface
         $errors = [];
         foreach ($properties as $property) {
             if (isset($property->schema->type, $property->schema->format)) {
-                $this->checkFormat($property->schema->type, $property->schema->format);
+                $type = $property->schema->type;
+                $type = is_array($type) ? current($type) : $type;
+                $this->checkFormat($type, $property->schema->format);
             }
         }
         $validator = new Validator();


### PR DESCRIPTION
If you use the `nullable` attribute, the `type` attribute is an array with `[ 'string', 'null' ]` in it. This will crash the `checkFormat` function which has a `string` type hint.
Fixes #45