### PR TITLE
allow strict validation of empty array when object is expected, as an option. (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,23 @@ $app->add(new HKarlstrom\Middleware\OpenApiValidation('/path/to/openapi.json'),[
 ]);
 ```
 
-| type                    | format    | default | description |
-| ----------------------- | ----------| ------- | --- |
-| additionalParameters    | bool      | false   | Allow additional parameters in query |
-| beforeHandler           | callable  | null    | Instructions [below](README.md#beforehandler) |
-| errorHandler            | callable  | null    | Instructions [below](README.md#errorhandler) |
-| exampleResponse         | bool      | false   | Return example response from openapi.json/openapi.yaml if route implementation is empty |
-| missingFormatException  | bool      | true    | Throw an exception if a format validator is missing |
-| pathNotFoundException   | bool      | true    | Throw an exception if the path is not found in openapi.json/openapi.yaml |
-| setDefaultParameters    | bool      | false   | Set the default parameter values for missing parameters and alter the request object |
-| stripResponse           | bool      | false   | Strip additional attributes from response to prevent response validation error |
-| stripResponseHeaders    | bool      | false   | Strip additional headers from response to prevent response validation error |
-| validateError           | bool      | false   | Should the error response be validated |
-| validateRequest         | bool      | true    | Should the request be validated |
-| validateResponse        | bool      | true    | Should the response's body be validated |
-| validateResponseHeaders | bool      | false   | Should the response's headers be validated |
+
+| type                       | format    | default | description |
+| -------------------------- | --------- | ------- | --- |
+| additionalParameters       | bool      | false   | Allow additional parameters in query |
+| beforeHandler              | callable  | null    | Instructions [below](README.md#beforehandler) |
+| errorHandler               | callable  | null    | Instructions [below](README.md#errorhandler) |
+| exampleResponse            | bool      | false   | Return example response from openapi.json/openapi.yaml if route implementation is empty |
+| missingFormatException     | bool      | true    | Throw an exception if a format validator is missing |
+| pathNotFoundException      | bool      | true    | Throw an exception if the path is not found in openapi.json/openapi.yaml |
+| setDefaultParameters       | bool      | false   | Set the default parameter values for missing parameters and alter the request object |
+| strictEmptyArrayValidation | bool      | false   | Consider empty array when object is expected as validation error |
+| stripResponse              | bool      | false   | Strip additional attributes from response to prevent response validation error |
+| stripResponseHeaders       | bool      | false   | Strip additional headers from response to prevent response validation error |
+| validateError              | bool      | false   | Should the error response be validated |
+| validateRequest            | bool      | true    | Should the request be validated |
+| validateResponse           | bool      | true    | Should the response's body be validated |
+| validateResponseHeaders    | bool      | false   | Should the response's headers be validated |
 
 
 #### beforeHandler

--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -52,6 +52,7 @@ class OpenApiValidation implements MiddlewareInterface
         'validateRequest'         => true,
         'validateResponse'        => true,
         'validateResponseHeaders' => false,
+        'strictEmptyArrayValidation' => false
     ];
     private $formatContainer;
 
@@ -564,8 +565,10 @@ class OpenApiValidation implements MiddlewareInterface
             }
             // As the request body is parsed as an array, empty object and empty array will both be []
             // Remove these errors
-            if ('error_type' == $err['code'] && empty($err['value']) && 'object' == $err['expected'] && 'array' == $err['used']) {
-                return [];
+            if (!$this->options['strictEmptyArrayValidation']) {
+                if ('error_type' == $err['code'] && empty($err['value']) && 'object' == $err['expected'] && 'array' == $err['used']) {
+                    return [];
+                }
             }
             $errors[] = $err;
         }

--- a/tests/RequestBodyTest.php
+++ b/tests/RequestBodyTest.php
@@ -48,6 +48,27 @@ class RequestBodyTest extends BaseTest
                 ['string', 'customFormat', new CustomFormat2()],
             ],
             'body' => [
+                'foo'    => 'test',
+                'bar'    => 123,
+                'person' => [
+                ],
+                'custom' => 'OK',
+            ],
+            'options'      => [
+                'strictEmptyArrayValidation' => true,
+            ],
+        ]);
+        $json = $this->json($response);
+        $errors = $json['errors'];
+        $this->assertSame('error_type', $errors[0]['code']);
+        $this->assertSame('body', $errors[0]['in']);
+        $this->assertSame('person', $errors[0]['name']);
+
+        $response = $this->response('post', '/request/body', [
+            'formats' => [
+                ['string', 'customFormat', new CustomFormat2()],
+            ],
+            'body' => [
                 'foo'    => 123,
                 'bar'    => 'test',
                 'person' => [


### PR DESCRIPTION
Add an option to deal with the case of objects with required parameters that are considered valid when empty instead of failing validation.
If not provided, it keeps the current functionality.
Closes #44 